### PR TITLE
configmap: map divergent configurations into a common format

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,70 @@
+package overmount
+
+import (
+	"time"
+)
+
+// ImageConfig is a portable, non-standard format used by overmount for the
+// generation of other configuration formats used in images. It is an attempt
+// to be abstract from the formats themselves. It is intentionally flat to
+// avoid merging problems with newer editions of overmount.
+//
+// NOTE: some portions of this code are taken from docker/docker and opencontainers/image-spec.
+type ImageConfig struct {
+	// ID is a unique 64 character identifier of the image
+	ID string `json:"id,omitempty"`
+
+	// Parent is the ID of the parent image
+	Parent string `json:"parent,omitempty"`
+
+	// Comment is the commit message that was set when committing the image
+	Comment string `json:"comment,omitempty"`
+
+	// Created is the timestamp at which the image was created
+	Created time.Time `json:"created"`
+
+	// Container is the id of the container used to commit
+	Container string `json:"container,omitempty"`
+
+	// ContainerConfig is the configuration of the container that is committed into the image
+	ContainerConfig interface{} `json:"container_config,omitempty"`
+
+	// DockerVersion specifies the version of Docker that was used to build the image
+	DockerVersion string `json:"docker_version,omitempty"`
+
+	// Author is the name of the author that was specified when committing the image
+	Author string `json:"author,omitempty"`
+
+	// Architecture is the hardware that the image is built and runs on
+	Architecture string `json:"architecture,omitempty"`
+
+	// OS is the operating system used to build and run the image
+	OS string `json:"os,omitempty"`
+
+	// User defines the username or UID which the process in the container should run as.
+	User string `json:"user,omitempty"`
+
+	// ExposedPorts a set of ports to expose from a container running this image.
+	ExposedPorts map[string]struct{} `json:"exposed_ports,omitempty"`
+
+	// Env is a list of environment variables to be used in a container.
+	Env []string `json:"env,omitempty"`
+
+	// Entrypoint defines a list of arguments to use as the command to execute when the container starts.
+	Entrypoint []string `json:"entrypoint,omitempty"`
+
+	// Cmd defines the default arguments to the entrypoint of the container.
+	Cmd []string `json:"cmd,omitempty"`
+
+	// Volumes is a set of directories which should be created as data volumes in a container running this image.
+	Volumes map[string]struct{} `json:"volumes,omitempty"`
+
+	// WorkingDir sets the current working directory of the entrypoint process in the container.
+	WorkingDir string `json:"working_dir,omitempty"`
+
+	// Labels contains arbitrary metadata for the container.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// StopSignal contains the system call signal that will be sent to the container to exit.
+	StopSignal string `json:"stopsignal,omitempty"`
+}

--- a/configmap/configmap.go
+++ b/configmap/configmap.go
@@ -1,0 +1,113 @@
+package configmap
+
+import (
+	"encoding/json"
+
+	"github.com/box-builder/overmount"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/image"
+	"github.com/docker/go-connections/nat"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func remarshalContainerConfig(cc interface{}) (container.Config, error) {
+	content, err := json.Marshal(cc)
+	config := container.Config{}
+	if err != nil {
+		return config, err
+	}
+
+	return config, json.Unmarshal(content, &config)
+}
+
+func convertFromPortSet(set nat.PortSet) map[string]struct{} {
+	myMap := map[string]struct{}{}
+
+	for key := range set {
+		myMap[string(key)] = struct{}{}
+	}
+
+	return myMap
+}
+
+func convertToPortSet(myMap map[string]struct{}) nat.PortSet {
+	set := nat.PortSet{}
+
+	for key := range myMap {
+		pb, err := nat.ParsePortSpec(key)
+		if err != nil {
+			continue
+		}
+
+		set[pb[0].Port] = struct{}{}
+	}
+
+	return set
+}
+
+// FromDockerV1 converts a docker image configuration to an overmount one.
+func FromDockerV1(img *image.V1Image) *overmount.ImageConfig {
+	return &overmount.ImageConfig{
+		ID:              img.ID,     // FIXME should be calculated
+		Parent:          img.Parent, // FIXME should be calculated
+		Comment:         img.Comment,
+		Created:         img.Created,
+		Container:       img.Container, // FIXME should be overridden
+		ContainerConfig: img.ContainerConfig,
+		DockerVersion:   img.DockerVersion,
+		Author:          img.Author,
+		Architecture:    img.Architecture,
+		OS:              img.OS,
+		User:            img.Config.User,
+		ExposedPorts:    convertFromPortSet(nat.PortSet(img.Config.ExposedPorts)),
+		Env:             img.Config.Env,
+		Entrypoint:      img.Config.Entrypoint,
+		Cmd:             img.Config.Cmd,
+		Volumes:         img.Config.Volumes,
+		WorkingDir:      img.Config.WorkingDir,
+		Labels:          img.Config.Labels,
+		StopSignal:      img.Config.StopSignal,
+	}
+}
+
+// FromOCIV1 converts an oci image configuration to an overmount one.
+func FromOCIV1(img *v1.Image) *overmount.ImageConfig {
+	return nil
+}
+
+// ToOCIV1 converts an overmount image configuration to an OCI one.
+func ToOCIV1(config *overmount.ImageConfig) *v1.Image {
+	return nil
+}
+
+// ToDockerV1 converts an overmount image configuration to a docker one.
+func ToDockerV1(config *overmount.ImageConfig) (*image.V1Image, error) {
+	cc, err := remarshalContainerConfig(config.ContainerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &image.V1Image{
+		ID:              config.ID,     // FIXME should be calculated
+		Parent:          config.Parent, // FIXME should be calculated
+		Comment:         config.Comment,
+		Created:         config.Created,
+		Container:       config.Container, // FIXME should be overridden
+		ContainerConfig: cc,
+		DockerVersion:   config.DockerVersion,
+		Author:          config.Author,
+		Architecture:    config.Architecture,
+		OS:              config.OS,
+		Config: &container.Config{
+			User:         config.User,
+			ExposedPorts: convertToPortSet(config.ExposedPorts),
+			Env:          config.Env,
+			Entrypoint:   config.Entrypoint,
+			Cmd:          config.Cmd,
+			Volumes:      config.Volumes,
+			WorkingDir:   config.WorkingDir,
+			Labels:       config.Labels,
+			StopSignal:   config.StopSignal,
+		},
+	}, nil
+}

--- a/imgio/docker_test.go
+++ b/imgio/docker_test.go
@@ -67,14 +67,7 @@ func (d *dockerSuite) TestDockerImportExport(c *C) {
 		for _, layer := range layers {
 			config, err := layer.Config()
 			c.Assert(err, IsNil, Commentf("%v", imageName))
-			c.Assert(config.Config.Cmd, DeepEquals, cmd, Commentf("%v", imageName))
-
-			var count int
-			for iter := layer; iter != nil; iter = iter.Parent {
-				count++
-			}
-
-			c.Assert(count, Equals, len(config.RootFS.DiffIDs))
+			c.Assert(config.Cmd, DeepEquals, cmd, Commentf("%v", imageName))
 
 			reader, err = d.repository.Export(docker, layer)
 			c.Assert(err, IsNil, Commentf("%v", imageName))

--- a/layer.go
+++ b/layer.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	digest "github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -115,19 +114,19 @@ func (l *Layer) configPath() string {
 }
 
 // Config returns a reference to the image configuration for this layer.
-func (l *Layer) Config() (*v1.Image, error) {
+func (l *Layer) Config() (*ImageConfig, error) {
 	f, err := os.Open(l.configPath())
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	var i v1.Image
+	var i ImageConfig
 	return &i, json.NewDecoder(f).Decode(&i)
 }
 
 // SaveConfig writes a *v1.Image configuration to the repository for the layer.
-func (l *Layer) SaveConfig(config *v1.Image) error {
+func (l *Layer) SaveConfig(config *ImageConfig) error {
 	return l.edit(func() error {
 		f, err := os.Create(l.configPath())
 		if err != nil {

--- a/layer_test.go
+++ b/layer_test.go
@@ -6,7 +6,6 @@ import (
 	"path"
 
 	digest "github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/specs-go/v1"
 
 	. "gopkg.in/check.v1"
 )
@@ -78,8 +77,8 @@ func (m *mountSuite) TestLayerConfig(c *C) {
 	config, err := layer.Config()
 	c.Assert(config, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(layer.SaveConfig(&v1.Image{Config: v1.ImageConfig{Cmd: []string{"quux"}}}), IsNil)
+	c.Assert(layer.SaveConfig(&ImageConfig{Cmd: []string{"quux"}}), IsNil)
 	config, err = layer.Config()
 	c.Assert(err, IsNil)
-	c.Assert(config.Config.Cmd, DeepEquals, []string{"quux"})
+	c.Assert(config.Cmd, DeepEquals, []string{"quux"})
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@ github.com/opencontainers/go-digest aa2ec055abd10d26d539eb630a92241b781ce4bc
 github.com/pkg/errors bfd5150e4e41705ded2129ec33379de1cb90b513
 gopkg.in/check.v1 20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 golang.org/x/sys 99f16d856c9836c42d24e7ab64ea72916925fa97
-github.com/docker/docker v1.13.1
+github.com/docker/docker 17.04.x
 github.com/Sirupsen/logrus v0.11.0
 github.com/opencontainers/runc 9c2d8d184e5da67c95d601382adf14862e4f2228 https://github.com/docker/runc.git
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
@@ -11,3 +11,7 @@ github.com/docker/go-connections 7da10c8c50cad14494ec818dcdfb6506265c0086
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/opencontainers/image-spec master
 github.com/urfave/cli v1.19.1
+github.com/vbatts/tar-split v0.10.1
+github.com/opencontainers/runtime-spec 1c7c27d043c2a5e513a44084d2b10d77d1402b8c
+github.com/gorilla/mux master
+github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a


### PR DESCRIPTION
Used for the overmount repo.

There are also some stubs for the OCI support here too; still unused.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>