### PR TITLE
Support for virtual layers; layers which are just tar files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,23 @@ vndr:
 install_box:
 	@sh install_box.sh
 
-test: install_box
+build: install_box
 	box -t box-builder/overmount build.rb
+
+test: build
 	make run-docker
+
+test-virtual: build
+	VIRTUAL=1 make run-docker
 
 test-ci:
 	@sh install_box_ci.sh
 	bin/box -t box-builder/overmount build.rb
 	make run-docker
+	VIRTUAL=1 make run-docker
 
 run-docker:
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v /tmp --privileged --rm box-builder/overmount
+	docker run -e VIRTUAL=${VIRTUAL} -v /var/run/docker.sock:/var/run/docker.sock -v /tmp --privileged --rm box-builder/overmount
 
 docker-deps:
 	go get github.com/opencontainers/image-tools/...

--- a/asset_test.go
+++ b/asset_test.go
@@ -20,7 +20,7 @@ func (m *mountSuite) TestAssetBasic(c *C) {
 	}
 
 	for dir, check := range dispatchTable {
-		asset, err := NewAsset(dir, digest.SHA256.Digester())
+		asset, err := NewAsset(dir, digest.SHA256.Digester(), false)
 		c.Assert(err, IsNil)
 		c.Assert(asset.Path(), Equals, dir)
 		c.Assert(asset.Digest(), Equals, emptyDigest)

--- a/examples/pull/main.go
+++ b/examples/pull/main.go
@@ -13,10 +13,10 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/box-builder/overmount"
 	"github.com/box-builder/overmount/imgio"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 func main() {
@@ -39,7 +39,7 @@ func main() {
 
 	fmt.Println("repository:", tmpdir)
 
-	repo, err := overmount.NewRepository(tmpdir)
+	repo, err := overmount.NewRepository(tmpdir, os.Getenv("OVERMOUNT_VIRTUAL") != "")
 	if err != nil {
 		panic(err)
 	}

--- a/image.go
+++ b/image.go
@@ -17,6 +17,10 @@ func (r *Repository) NewImage(topLayer *Layer) *Image {
 //
 // Call unmount to undo this operation.
 func (i *Image) Mount() error {
+	if i.repository.IsVirtual() {
+		return errors.Wrap(ErrMountCannotProceed, "cannot mount in virtual repository")
+	}
+
 	upper := i.layer.Path()
 	target := i.layer.MountPath()
 

--- a/image_test.go
+++ b/image_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func (m *mountSuite) TestImageMountUnmount(c *C) {
+	if m.Repository.IsVirtual() {
+		c.Skip("Cannot mount virtual layers")
+		return
+	}
+
 	image, layer := m.makeImage(c, 2)
 
 	image2 := m.Repository.NewImage(layer.Parent) // only one layer

--- a/imgio/docker_test.go
+++ b/imgio/docker_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 	. "testing"
 
@@ -33,7 +34,7 @@ func (d *dockerSuite) SetUpTest(c *C) {
 		panic(err)
 	}
 
-	d.repository, err = om.NewRepository(tmpdir)
+	d.repository, err = om.NewRepository(tmpdir, os.Getenv("VIRTUAL") != "")
 	if err != nil {
 		panic(err)
 	}

--- a/layer.go
+++ b/layer.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	rootFSPath   = "rootfs"
-	parentPath   = "parent"
-	configPath   = "config.json"
-	lockFilePath = "lockfile"
+	rootFSPath       = "rootfs"
+	parentPath       = "parent"
+	configPath       = "config.json"
+	lockFilePath     = "lockfile"
+	virtualLayerPath = "layer.tar"
 )
 
 // CreateLayer prepares a new layer for work and creates it in the repository.
@@ -53,7 +54,7 @@ func (r *Repository) newLayer(id string, parent *Layer, create bool) (*Layer, er
 		return nil, err
 	}
 
-	layer.asset, err = NewAsset(layer.Path(), digest.SHA256.Digester())
+	layer.asset, err = NewAsset(layer.Path(), digest.SHA256.Digester(), r.IsVirtual())
 	if err != nil {
 		return nil, err
 	}
@@ -102,6 +103,10 @@ func (l *Layer) layerBase() string {
 
 // Path gets the layer store path for a given subpath.
 func (l *Layer) Path() string {
+	if l.repository.IsVirtual() {
+		return filepath.Join(l.layerBase(), virtualLayerPath)
+	}
+
 	return filepath.Join(l.layerBase(), rootFSPath)
 }
 

--- a/layer_test.go
+++ b/layer_test.go
@@ -3,6 +3,7 @@ package overmount
 import (
 	"compress/gzip"
 	"net/http"
+	"os"
 	"path"
 
 	digest "github.com/opencontainers/go-digest"
@@ -51,7 +52,7 @@ func (m *mountSuite) TestLayerParentCommit(c *C) {
 
 	parentID := layer.Parent.ID()
 	id := layer.ID()
-	m.Repository, err = NewRepository(m.Repository.baseDir)
+	m.Repository, err = NewRepository(m.Repository.baseDir, os.Getenv("VIRTUAL") != "")
 	c.Assert(err, IsNil)
 	layer, err = m.Repository.NewLayer(id, nil)
 	c.Assert(err, IsNil)
@@ -63,7 +64,7 @@ func (m *mountSuite) TestLayerParentCommit(c *C) {
 	}
 
 	c.Assert(count, Equals, layerCount)
-	m.Repository, err = NewRepository(m.Repository.baseDir)
+	m.Repository, err = NewRepository(m.Repository.baseDir, os.Getenv("VIRTUAL") != "")
 	c.Assert(err, IsNil)
 	layer, err = m.Repository.NewLayer(id, nil)
 	layer.Parent = nil

--- a/om/om.go
+++ b/om/om.go
@@ -32,6 +32,11 @@ func main() {
 			EnvVar: "OVERMOUNT_REPO",
 			Value:  path.Join(os.Getenv("HOME"), ".overmount"),
 		},
+		cli.BoolFlag{
+			Name:   "virtual",
+			Usage:  "Switch on virtual repositories (keeping tar files only, no expansion of files)",
+			EnvVar: "OVERMOUNT_VIRTUAL",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -82,7 +87,7 @@ func main() {
 }
 
 func constructImage(ctx *cli.Context) (*overmount.Image, *overmount.Layer) {
-	repo, err := overmount.NewRepository(ctx.GlobalString("repo"))
+	repo, err := overmount.NewRepository(ctx.GlobalString("repo"), ctx.GlobalBool("virtual"))
 	if err != nil {
 		errExit(2, err)
 	}
@@ -115,7 +120,7 @@ func unmountImage(ctx *cli.Context) {
 }
 
 func mountImage(ctx *cli.Context) {
-	repo, err := overmount.NewRepository(ctx.GlobalString("repo"))
+	repo, err := overmount.NewRepository(ctx.GlobalString("repo"), ctx.GlobalBool("virtual"))
 	if err != nil {
 		errExit(2, err)
 	}
@@ -143,7 +148,7 @@ func mountImage(ctx *cli.Context) {
 }
 
 func exportImage(ctx *cli.Context) {
-	repo, err := overmount.NewRepository(ctx.GlobalString("repo"))
+	repo, err := overmount.NewRepository(ctx.GlobalString("repo"), ctx.GlobalBool("virtual"))
 	if err != nil {
 		errExit(2, err)
 	}
@@ -191,7 +196,7 @@ func exportImage(ctx *cli.Context) {
 }
 
 func importImage(ctx *cli.Context) {
-	repo, err := overmount.NewRepository(ctx.GlobalString("repo"))
+	repo, err := overmount.NewRepository(ctx.GlobalString("repo"), ctx.GlobalBool("virtual"))
 	if err != nil {
 		errExit(2, err)
 	}
@@ -226,7 +231,7 @@ func importImage(ctx *cli.Context) {
 }
 
 func listLayers(ctx *cli.Context) {
-	repo, err := overmount.NewRepository(ctx.GlobalString("repo"))
+	repo, err := overmount.NewRepository(ctx.GlobalString("repo"), ctx.GlobalBool("virtual"))
 	if err != nil {
 		errExit(2, err)
 	}

--- a/overmount.go
+++ b/overmount.go
@@ -75,6 +75,7 @@ type Repository struct {
 	baseDir string
 	layers  map[string]*Layer
 	mounts  []*Mount
+	virtual bool
 
 	editMutex *sync.Mutex
 }
@@ -105,6 +106,7 @@ type Layer struct {
 	id         string
 	asset      *Asset
 	repository *Repository
+	virtual    bool
 
 	editMutex *sync.Mutex
 }

--- a/repository.go
+++ b/repository.go
@@ -16,13 +16,20 @@ const lockFile = "repository.lock"
 
 // NewRepository constructs a *Repository and creates the dir in which the
 // repository lives. A repository is used to hold images and mounts.
-func NewRepository(baseDir string) (*Repository, error) {
+func NewRepository(baseDir string, virtual bool) (*Repository, error) {
 	return &Repository{
 		baseDir:   baseDir,
 		layers:    map[string]*Layer{},
 		mounts:    []*Mount{},
 		editMutex: new(sync.Mutex),
+		virtual:   virtual,
 	}, os.MkdirAll(baseDir, 0700)
+}
+
+// IsVirtual reports if the repository is virtual. Virtual repositories hold
+// tars and cannot accept mounts.
+func (r *Repository) IsVirtual() bool {
+	return r.virtual
 }
 
 // TempDir returns a temporary path within the repository

--- a/repository_test.go
+++ b/repository_test.go
@@ -9,13 +9,13 @@ import (
 func (m *mountSuite) TestBasicRepository(c *C) {
 	tempdir, err := ioutil.TempDir("", "")
 	c.Assert(err, IsNil)
-	r, err := NewRepository(tempdir)
+	r, err := NewRepository(tempdir, false)
 	c.Assert(err, IsNil)
 	c.Assert(r.baseDir, Equals, tempdir)
 	c.Assert(r.editMutex, NotNil)
 	c.Assert(r.layers, NotNil)
 	c.Assert(r.mounts, NotNil)
-	_, err = NewRepository("/dev/zero")
+	_, err = NewRepository("/dev/zero", false)
 	c.Assert(err, NotNil)
 
 	r.baseDir = "/dev/zero"
@@ -24,6 +24,11 @@ func (m *mountSuite) TestBasicRepository(c *C) {
 }
 
 func (m *mountSuite) TestRepositoryPropagation(c *C) {
+	if m.Repository.IsVirtual() {
+		c.Skip("Cannot mount virtual layers")
+		return
+	}
+
 	image, layer := m.makeImage(c, 2)
 	c.Assert(image.Mount(), IsNil)
 	c.Assert(len(m.Repository.mounts), Equals, 1)


### PR DESCRIPTION
This allows box to work with layers without knowledge of their contents. This enables things in overmount like tar reprocessing without root or even the filesystem available (hi, macos x). It may also enable patterns with nondistributable or protected layers.

Note that you cannot actually MOUNT anything in a virtual repository; this is because the tar files live on disk and not the contents of them.