### PR TITLE
Tagging

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -28,8 +28,14 @@ func (r *Repository) CreateLayer(id string, parent *Layer) (*Layer, error) {
 
 // NewLayer prepares a new layer for work but DOES NOT add it to the
 // repository. The ID is the directory that will be created in the repository;
-// see NewRepository for more info.
+// see NewRepository for more info. If the layer is already in the repository
+// and known, it will be returned and no file operations or checks will be
+// performed. The layer may not actually exist at this point.
 func (r *Repository) NewLayer(id string, parent *Layer) (*Layer, error) {
+	if layer, ok := r.layers[id]; ok {
+		return layer, nil
+	}
+
 	return r.newLayer(id, parent, false)
 }
 

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,87 @@
+package overmount
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+)
+
+const tagsDB = "tags"
+
+var (
+	// ErrTagDoesNotExist is reported when the tag retrieved or removed does not exist
+	ErrTagDoesNotExist = errors.New("tag does not exist")
+)
+
+func (r *Repository) tagFileFor(name string) string {
+	return path.Join(r.baseDir, tagsDB, name)
+}
+
+// AddTag tags a layer with the name
+func (r *Repository) AddTag(name string, layer *Layer) error {
+	return r.edit(func() error {
+		f, err := ioutil.TempFile("", "temp-tag")
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if _, err := f.WriteString(layer.ID()); err != nil {
+			return err
+		}
+		f.Close()
+
+		if err := os.MkdirAll(path.Join(r.baseDir, tagsDB), 0700); err != nil {
+			return err
+		}
+
+		if err := os.Rename(f.Name(), r.tagFileFor(name)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// RemoveTag removes a tag by name.
+func (r *Repository) RemoveTag(name string) error {
+	return r.edit(func() error {
+		err := os.Remove(r.tagFileFor(name))
+		if os.IsNotExist(err) {
+			return errors.Wrap(ErrTagDoesNotExist, "cannot remove")
+		}
+		return err
+	})
+}
+
+// GetTag retrieves the layer by the tag name. Returns an error if the tag or
+// layer cannot be found. NOTE: the layer is *not* restored.
+func (r *Repository) GetTag(name string) (*Layer, error) {
+	f, err := os.Open(r.tagFileFor(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.Wrap(ErrTagDoesNotExist, "file not found")
+		}
+
+		return nil, err
+	}
+
+	defer f.Close()
+
+	id, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := r.NewLayer(string(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if !l.Exists() {
+		return nil, errors.Wrap(ErrTagDoesNotExist, "referenced layer does not exist")
+	}
+
+	return l, nil
+}

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,24 @@
+package overmount
+
+import (
+	"github.com/pkg/errors"
+	. "gopkg.in/check.v1"
+)
+
+func (m *mountSuite) TestTags(c *C) {
+	_, err := m.Repository.GetTag("test")
+	c.Assert(errors.Cause(err), Equals, ErrTagDoesNotExist)
+
+	err = m.Repository.RemoveTag("test")
+	c.Assert(errors.Cause(err), Equals, ErrTagDoesNotExist)
+
+	_, layer := m.makeImage(c, 2)
+	c.Assert(m.Repository.AddTag("test", layer), IsNil)
+
+	layer2, err := m.Repository.GetTag("test")
+	c.Assert(err, IsNil)
+
+	c.Assert(layer2.ID(), Equals, layer.ID())
+	c.Assert(layer2.RestoreParent(), IsNil)
+	c.Assert(layer2.Parent.ID(), Equals, layer.Parent.ID())
+}


### PR DESCRIPTION
This implements a tagging store and interacts with the layer store via the repository handle. It should work effectively for one-way lookup of tags, which can be useful for creating images. They will not necessarily be used for creating images though, so they are not tightly integrated with imgio, still figuring that out.

om supports tagging and getting tag information now.