### PR TITLE
Fix for temporary file/dir handling

### DIFF
--- a/imgio/docker_import.go
+++ b/imgio/docker_import.go
@@ -30,7 +30,7 @@ type unpackedImage struct {
 // it into the overmount repository.  Returns the top-most layer and any
 // error.
 func (d *Docker) Import(r *om.Repository, reader io.ReadCloser) ([]*om.Layer, error) {
-	tempdir, err := ioutil.TempDir("", "overmount-unpack-")
+	tempdir, err := r.TempDir()
 	if err != nil {
 		return nil, err
 	}

--- a/om/om.go
+++ b/om/om.go
@@ -200,7 +200,7 @@ func exportImage(ctx *cli.Context) {
 		exporter = imgio.NewOCI()
 	}
 
-	reader, err := exporter.Export(layer)
+	reader, err := exporter.Export(repo, layer)
 	if err != nil {
 		errExit(2, err)
 	}

--- a/overmount.go
+++ b/overmount.go
@@ -131,5 +131,5 @@ type Importer interface {
 // overmount repositories.
 type Exporter interface {
 	// Export produces a tar represented as an io.ReadCloser from the Layer provided.
-	Export(*Layer) (io.ReadCloser, error)
+	Export(*Repository, *Layer) (io.ReadCloser, error)
 }

--- a/repository.go
+++ b/repository.go
@@ -41,6 +41,15 @@ func (r *Repository) TempDir() (string, error) {
 	return ioutil.TempDir(basePath, "")
 }
 
+// TempFile returns a temporary file within the repository
+func (r *Repository) TempFile() (*os.File, error) {
+	basePath := filepath.Join(r.baseDir, tmpdirBase)
+	if err := os.MkdirAll(basePath, 0700); err != nil {
+		return nil, err
+	}
+	return ioutil.TempFile(basePath, "")
+}
+
 // NewMount creates a new mount for use. Target, lower, and upper correspond to
 // specific fields in the mount stanza; read
 // https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt for more
@@ -128,5 +137,5 @@ func (r *Repository) Import(i Importer, reader io.ReadCloser) ([]*Layer, error) 
 
 // Export an image (provided via writer) from the repository.
 func (r *Repository) Export(e Exporter, layer *Layer) (io.ReadCloser, error) {
-	return e.Export(layer)
+	return e.Export(r, layer)
 }

--- a/tags.go
+++ b/tags.go
@@ -22,7 +22,7 @@ func (r *Repository) tagFileFor(name string) string {
 // AddTag tags a layer with the name
 func (r *Repository) AddTag(name string, layer *Layer) error {
 	return r.edit(func() error {
-		f, err := ioutil.TempFile("", "temp-tag")
+		f, err := r.TempFile()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This scopes all temporary file handling under the overmount repository path.